### PR TITLE
custom access entry type

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,22 @@ If access denied, the `WWW-Authenticate` header returned will resemble the follo
 WWW-Authenticate: Bearer realm="https://my.site.io/oauth2/token",service="my.site.io",scope="artifact-repository:org1/repo1:push"
 ```
 
+### Using a custom access entry type
+
+By default, the "Type" of each claim checked for upon authorization is `artifact-repository`.
+
+If you wish, you may customize this field upon construction of the Authorizer:
+
+For example, for custom type "myartifact", you do the following:
+```go
+myAuthorizer, err = NewAuthorizer(&AuthorizerOptions{
+    Realm:           "https://my.site.io/oauth2/token",
+    Service:         "my.site.io",
+    PublicKeyPath:   myPublicKey,
+    AccessEntryType: "myartifact", // <-------
+})
+```
+
 ## Supported JWT Signing Algorithms
 
 - RS256

--- a/authorization.go
+++ b/authorization.go
@@ -46,6 +46,7 @@ type (
 		BasicAuthMatchHeader string
 		TokenDecoder         *TokenDecoder
 		AnonymousActions     []string
+		AccessEntryType      string
 	}
 
 	// BasicAuthAuthorizerOptions is TODO
@@ -57,6 +58,7 @@ type (
 		PublicKey        []byte
 		PublicKeyPath    string
 		AnonymousActions []string
+		AccessEntryType  string
 	}
 
 	// Permission is TODO
@@ -71,6 +73,12 @@ func NewAuthorizer(opts *AuthorizerOptions) (*Authorizer, error) {
 	authorizer := Authorizer{
 		Realm:            opts.Realm,
 		AnonymousActions: opts.AnonymousActions,
+	}
+
+	if opts.AccessEntryType == "" {
+		authorizer.AccessEntryType = AccessEntryType
+	} else {
+		authorizer.AccessEntryType = opts.AccessEntryType
 	}
 
 	if opts.Username != "" && opts.Password != "" {
@@ -151,7 +159,7 @@ func (authorizer *Authorizer) authorizeBearerAuth(authHeader string, action stri
 		claims, err := getTokenCustomClaims(token)
 		if err == nil {
 			for _, entry := range claims.Access {
-				if entry.Type == AccessEntryType {
+				if entry.Type == authorizer.AccessEntryType {
 					if entry.Name == namespace {
 						for _, act := range entry.Actions {
 							if act == action {
@@ -173,7 +181,7 @@ func (authorizer *Authorizer) authorizeBearerAuth(authHeader string, action stri
 			namespace = DefaultNamespace
 		}
 		wwwAuthenticateHeader = fmt.Sprintf("Bearer realm=\"%s\",service=\"%s\",scope=\"%s:%s:%s\"",
-			authorizer.Realm, authorizer.Service, AccessEntryType, namespace, action)
+			authorizer.Realm, authorizer.Service, authorizer.AccessEntryType, namespace, action)
 	}
 
 	permission := Permission{


### PR DESCRIPTION
Allow for use of a different access entry type, other than just "artifact-repository"