### PR TITLE
Feature/jmespath

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -17,9 +17,13 @@ limitations under the License.
 package auth
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/jmespath/go-jmespath"
 	"github.com/pkg/errors"
+	"reflect"
 	"regexp"
+	"strings"
 )
 
 const (
@@ -42,28 +46,30 @@ type (
 
 	// Authorizer is TODO
 	Authorizer struct {
-		Type                 AuthorizerType
-		Realm                string
-		Service              string
-		BasicAuthMatchHeader string
-		TokenDecoder         *TokenDecoder
-		AnonymousActions     []string
-		AccessEntryType      string
-		DefaultNamespace	 string
+		Type                 		AuthorizerType
+		Realm                		string
+		Service              		string
+		BasicAuthMatchHeader 		string
+		TokenDecoder         		*TokenDecoder
+		AnonymousActions     		[]string
+		AccessEntryType      		string
+		DefaultNamespace	 		string
+		AllowedActionsSearchPath	string
 	}
 
 	// BasicAuthAuthorizerOptions is TODO
 	AuthorizerOptions struct {
-		Realm                 string
-		Service               string
-		Username              string
-		Password              string
-		PublicKey             []byte
-		PublicKeyPath         string
-		AnonymousActions      []string
-		AccessEntryType       string
-		DefaultNamespace	  string
-		EmptyDefaultNamespace bool
+		Realm                    string
+		Service                  string
+		Username                 string
+		Password                 string
+		PublicKey                []byte
+		PublicKeyPath            string
+		AnonymousActions         []string
+		AccessEntryType          string
+		DefaultNamespace         string
+		EmptyDefaultNamespace    bool
+		AllowedActionsSearchPath string
 	}
 
 	// Permission is TODO
@@ -98,6 +104,12 @@ func NewAuthorizer(opts *AuthorizerOptions) (*Authorizer, error) {
 		authorizer.AccessEntryType = AccessEntryType
 	} else {
 		authorizer.AccessEntryType = opts.AccessEntryType
+	}
+
+	if opts.AllowedActionsSearchPath == "" {
+		authorizer.AllowedActionsSearchPath = AllowedActionsSearchPath
+	} else {
+		authorizer.AllowedActionsSearchPath = opts.AllowedActionsSearchPath
 	}
 
 	if opts.Username != "" && opts.Password != "" {
@@ -177,23 +189,24 @@ func (authorizer *Authorizer) authorizeBearerAuth(authHeader string, action stri
 	// TODO log error
 	token, err := authorizer.TokenDecoder.DecodeToken(signedString)
 	if err == nil {
-
-		// TODO log error
-		claims, err := getTokenCustomClaims(token)
+		byteData, err := json.Marshal(token.Claims)
 		if err == nil {
-			for _, entry := range claims.Access {
-				if entry.Type == authorizer.AccessEntryType {
-					if entry.Name == namespace {
-						for _, act := range entry.Actions {
-							if act == action {
+			var data interface{}
+			err := json.Unmarshal(byteData, &data)
+			if err == nil {
+				allowedActionsSearchPath := strings.ReplaceAll(strings.ReplaceAll(authorizer.AllowedActionsSearchPath, "$NAMESPACE", namespace), "$ACCESS_ENTRY_TYPE", authorizer.AccessEntryType)
+				result, err := jmespath.Search(allowedActionsSearchPath, data)
+				if err == nil {
+					switch reflect.TypeOf(result).Kind() {
+					case reflect.Slice:
+						allowedActions := reflect.ValueOf(result)
+						for i := 0; i < allowedActions.Len(); i++ {
+							if fmt.Sprintf("%v", allowedActions.Index(i)) == action {
 								allowed = true
 								break
 							}
 						}
 					}
-				}
-				if allowed {
-					break
 				}
 			}
 		}

--- a/authorization.go
+++ b/authorization.go
@@ -46,15 +46,15 @@ type (
 
 	// Authorizer is TODO
 	Authorizer struct {
-		Type                 		AuthorizerType
-		Realm                		string
-		Service              		string
-		BasicAuthMatchHeader 		string
-		TokenDecoder         		*TokenDecoder
-		AnonymousActions     		[]string
-		AccessEntryType      		string
-		DefaultNamespace	 		string
-		AllowedActionsSearchPath	string
+		Type                     AuthorizerType
+		Realm                    string
+		Service                  string
+		BasicAuthMatchHeader     string
+		TokenDecoder             *TokenDecoder
+		AnonymousActions         []string
+		AccessEntryType          string
+		DefaultNamespace         string
+		AllowedActionsSearchPath string
 	}
 
 	// BasicAuthAuthorizerOptions is TODO

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/jmespath/go-jmespath v0.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -11,5 +15,7 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/token.go
+++ b/token.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	AccessEntryType = "artifact-repository"
+	AllowedActionsSearchPath = "access[?name=='$NAMESPACE' && type=='$ACCESS_ENTRY_TYPE'].actions[]"
 )
 
 type (

--- a/token.go
+++ b/token.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	AccessEntryType = "artifact-repository"
+	AccessEntryType          = "artifact-repository"
 	AllowedActionsSearchPath = "access[?name=='$NAMESPACE' && type=='$ACCESS_ENTRY_TYPE'].actions[]"
 )
 


### PR DESCRIPTION
# JMESPath Support

Not every JWT token provider is able to define the token the way the chartmuseum wants it. 
In my case, my sso produces e.g.:

```
"resource_access": {
    "chartmuseum": {
      "roles": [
        "pull"
      ]
    }
  },
```
If you are not able to configure the JWT token provider yourself, i think it is a good idea to provide a solution by the chartmuseum auth module. 

With JMESPath Support we can make the path to find the allowed actions configurable.
To avoid a breaking change, i defined a default JMESPath. This default configuration does the same job as the old implementation. 

The pull request for the chartmuseum repository: https://github.com/helm/chartmuseum/pull/381
